### PR TITLE
Fix a Homebrew warning message

### DIFF
--- a/Formula/awsls.rb
+++ b/Formula/awsls.rb
@@ -3,7 +3,6 @@ class Awsls < Formula
   desc "A list command for AWS resources"
   homepage "https://github.com/jckuester/awsls"
   version "0.11.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/jckuester/awsls/releases/download/v0.11.0/awsls_0.11.0_darwin_amd64.tar.gz"


### PR DESCRIPTION
Fixes #1

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the jckuester/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/jckuester/homebrew-tap/Formula/awsls.rb:6
```